### PR TITLE
Update ufo_functions.hpp

### DIFF
--- a/6-functions/ufo_functions.hpp
+++ b/6-functions/ufo_functions.hpp
@@ -1,4 +1,6 @@
 #include <vector>
+#include <iostream>
+//was a error whit the type in std::sring
 
 void display_misses(int misses);
 


### PR DESCRIPTION
In the std::string type, wit the declaration in display_status, can't recognize the std::string because <iostream> it's not included.